### PR TITLE
modify bash_completion in .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -61,7 +61,7 @@ _isroot=false
   # COMPLETION {{{
     complete -cf sudo
     if [[ -f /etc/bash_completion ]]; then
-      ./etc/bash_completion
+      . /etc/bash_completion
     fi
   #}}}
 #}}}


### PR DESCRIPTION
hi,your .bashrc file is great,thank you!
My linux verson is ubuntu 14.04 LTS.when I copy r file and source .bashrc.Then I get a warning:
~bash:/etc/bash_completion: No such file. Then I check your .vimrc in num:64,I add a space between
" . " and "/etc....",then it works~~
